### PR TITLE
Switch to ffmpeg-the-third and remove bundled sdl2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-video"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT"
 description = "a video library for egui"
@@ -16,12 +16,12 @@ from_bytes = ["dep:tempfile"]
 [dependencies]
 egui = "0.22.0"
 atomic = "0.5.3"
-ffmpeg-next = { git = "https://github.com/n00kii/rust-ffmpeg.git", version = "6.0.0" }
+ffmpeg-the-third = "1.2.2"
 anyhow = "1.0.66"
 timer = "0.2.0"
 chrono = "0.4.22"
 tempfile = { version = "3.3.0", optional = true }
-sdl2 = { version = "0.35.2", features = ["bundled"]}
+sdl2 = { version = "0.35.2" }
 ringbuf = "0.3.1"
 parking_lot = "0.12.1"
 itertools = "0.10.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ authors = ["n00kii"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["sdl2/bundled"]
 from_bytes = ["dep:tempfile"]
+# will compile sdl2 for you if you do not have it
+# this may require other dependancies (see https://github.com/Rust-SDL2/rust-sdl2#bundled-feature)
+sdl2-bundled = ["sdl2/bundled"]
 
 [dependencies]
 egui = "0.22.0"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,4 +1,3 @@
-extern crate ffmpeg_next as ffmpeg;
 use eframe::NativeOptions;
 use egui::{CentralPanel, DragValue, Grid, Sense, Slider, TextEdit, Window};
 use egui_video::{AudioDevice, Player};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,170 @@
 //! egui-video
 //! video playback library for [`egui`]
 //!
+//! # Example
+//!
+//! This example can also be found in the `examples` directory.
+//!
+//! ```rust
+//! use eframe::NativeOptions;
+//! use egui::{CentralPanel, DragValue, Grid, Sense, Slider, TextEdit, Window};
+//! use egui_video::{AudioDevice, Player};
+//! fn main() {
+//!     let _ = eframe::run_native(
+//!         "app",
+//!         NativeOptions::default(),
+//!         Box::new(|_| Box::new(App::default())),
+//!     );
+//! }
+//! struct App {
+//!     audio_device: AudioDevice,
+//!     player: Option<Player>,
+//!
+//!     media_path: String,
+//!     stream_size_scale: f32,
+//!     seek_frac: f32,
+//! }
+//!
+//! impl Default for App {
+//!     fn default() -> Self {
+//!         Self {
+//!             audio_device: egui_video::init_audio_device(&sdl2::init().unwrap().audio().unwrap())
+//!                 .unwrap(),
+//!             media_path: String::new(),
+//!             stream_size_scale: 1.,
+//!             seek_frac: 0.,
+//!             player: None,
+//!         }
+//!     }
+//! }
+//!
+//! impl eframe::App for App {
+//!     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+//!         ctx.request_repaint();
+//!         CentralPanel::default().show(ctx, |ui| {
+//!             ui.horizontal(|ui| {
+//!                 ui.add_enabled_ui(!self.media_path.is_empty(), |ui| {
+//!                     if ui.button("load").clicked() {
+//!                         match Player::new(ctx, &self.media_path.replace("\"", ""))
+//!                             .and_then(|p| p.with_audio(&mut self.audio_device))
+//!                         {
+//!                             Ok(player) => {
+//!                                 self.player = Some(player);
+//!                             }
+//!                             Err(e) => println!("failed to make stream: {e}"),
+//!                         }
+//!                     }
+//!                 });
+//!                 ui.add_enabled_ui(!self.media_path.is_empty(), |ui| {
+//!                     if ui.button("clear").clicked() {
+//!                         self.player = None;
+//!                     }
+//!                 });
+//!
+//!                 let tedit_resp = ui.add_sized(
+//!                     [ui.available_width(), ui.available_height()],
+//!                     TextEdit::singleline(&mut self.media_path)
+//!                         .hint_text("click to set path")
+//!                         .interactive(false),
+//!                 );
+//!
+//!                 if ui
+//!                     .interact(
+//!                         tedit_resp.rect,
+//!                         tedit_resp.id.with("click_sense"),
+//!                         Sense::click(),
+//!                     )
+//!                     .clicked()
+//!                 {
+//!                     if let Some(path_buf) = rfd::FileDialog::new()
+//!                         .add_filter("videos", &["mp4", "gif", "webm"])
+//!                         .pick_file()
+//!                     {
+//!                         self.media_path = path_buf.as_path().to_string_lossy().to_string();
+//!                     }
+//!                 }
+//!             });
+//!             ui.separator();
+//!             if let Some(player) = self.player.as_mut() {
+//!                 Window::new("info").show(ctx, |ui| {
+//!                     Grid::new("info_grid").show(ui, |ui| {
+//!                         ui.label("frame rate");
+//!                         ui.label(player.framerate.to_string());
+//!                         ui.end_row();
+//!
+//!                         ui.label("size");
+//!                         ui.label(format!("{}x{}", player.width, player.height));
+//!                         ui.end_row();
+//!
+//!                         ui.label("elapsed / duration");
+//!                         ui.label(player.duration_text());
+//!                         ui.end_row();
+//!
+//!                         ui.label("state");
+//!                         ui.label(format!("{:?}", player.player_state.get()));
+//!                         ui.end_row();
+//!
+//!                         ui.label("has audio?");
+//!                         ui.label(player.audio_streamer.is_some().to_string());
+//!                         ui.end_row();
+//!                     });
+//!                 });
+//!                 Window::new("controls").show(ctx, |ui| {
+//!                     ui.horizontal(|ui| {
+//!                         if ui.button("seek to:").clicked() {
+//!                             player.seek(self.seek_frac);
+//!                         }
+//!                         ui.add(
+//!                             DragValue::new(&mut self.seek_frac)
+//!                                 .speed(0.05)
+//!                                 .clamp_range(0.0..=1.0),
+//!                         );
+//!                         ui.checkbox(&mut player.looping, "loop");
+//!                     });
+//!                     ui.horizontal(|ui| {
+//!                         ui.label("size scale");
+//!                         ui.add(Slider::new(&mut self.stream_size_scale, 0.0..=2.));
+//!                     });
+//!                     ui.separator();
+//!                     ui.horizontal(|ui| {
+//!                         if ui.button("play").clicked() {
+//!                             player.start()
+//!                         }
+//!                         if ui.button("unpause").clicked() {
+//!                             player.resume();
+//!                         }
+//!                         if ui.button("pause").clicked() {
+//!                             player.pause();
+//!                         }
+//!                         if ui.button("stop").clicked() {
+//!                             player.stop();
+//!                         }
+//!                     });
+//!                     ui.horizontal(|ui| {
+//!                         ui.label("volume");
+//!                         let mut volume = player.audio_volume.get();
+//!                         if ui
+//!                             .add(Slider::new(&mut volume, 0.0..=player.max_audio_volume))
+//!                             .changed()
+//!                         {
+//!                             player.audio_volume.set(volume);
+//!                         };
+//!                     });
+//!                 });
+//!
+//!                 player.ui(
+//!                     ui,
+//!                     [
+//!                         player.width as f32 * self.stream_size_scale,
+//!                         player.height as f32 * self.stream_size_scale,
+//!                     ],
+//!                 );
+//!             }
+//!         });
+//!     }
+//! }
+//! ```
+
 extern crate ffmpeg_the_third as ffmpeg;
 use anyhow::Result;
 use atomic::Atomic;
@@ -217,7 +381,7 @@ impl Player {
         self.set_state(PlayerState::Stopped)
     }
     /// Directly stop the stream. Use if you need to immmediately end the streams, and/or you
-    /// aren't able to call the player's [`ui`]/[`ui_at`] functions later on.
+    /// aren't able to call the player's [`Player::ui`]/[`Player::ui_at`] functions later on.
     pub fn stop_direct(&mut self) {
         self.frame_thread = None;
         self.audio_thread = None;


### PR DESCRIPTION
Since ffmpeg-next is abandonded and ffmpeg-the-third is the current maintainted ffmpeg repo, I thought it would be nice to change this to that crate. I have also removed bundled sdl which causes problems in the msys compiler. The use should install ffmpeg and sdl on their own as most rust C ffi libraries expect us to do.

Feel free to look into it, if it's okay then this crate can be published to crates.io as prerelease too. That would allow integration better.

I need this crate to stop depending on libmpv-rs which is very utterly unmaintained.