### PR TITLE
Spelling and player for streaming video over UDP socket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["n00kii"]
 default = ["sdl2/bundled"]
 from_bytes = ["dep:tempfile"]
 # will compile sdl2 for you if you do not have it
-# this may require other dependancies (see https://github.com/Rust-SDL2/rust-sdl2#bundled-feature)
+# this may require other dependencies (see https://github.com/Rust-SDL2/rust-sdl2#bundled-feature)
 sdl2-bundled = ["sdl2/bundled"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # egui-video, a video playing library for [`egui`](https://github.com/emilk/egui)
+
 [![crates.io](https://img.shields.io/crates/v/egui-video)](https://crates.io/crates/egui-video/0.5.2)
 [![docs](https://docs.rs/egui-video/badge.svg)](https://docs.rs/egui-video/0.5.2/egui_video/)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/n00kii/egui-video/blob/main/README.md)
 
-https://github.com/n00kii/egui-video/assets/57325298/c618ff0a-9ad2-4cf0-b14a-dda65dc54b23
+![Demo](https://github.com/n00kii/egui-video/assets/57325298/c618ff0a-9ad2-4cf0-b14a-dda65dc54b23)
 
-plays videos in egui from file path or from bytes
+Plays videos in egui from file path or from bytes.
 
-## dependancies:
- - requires ffmpeg 6. follow the build instructions [here](https://github.com/zmwangx/rust-ffmpeg/wiki/Notes-on-building)
- - requires sdl2. by default, a feature is enabled to automatically compile it for you, but you are free to disable it and follow [these instructions](https://github.com/Rust-SDL2/rust-sdl2#requirements)
-## usage:
+## Dependencies
+
+- Requires ffmpeg 6. Follow the build instructions [here](https://github.com/zmwangx/rust-ffmpeg/wiki/Notes-on-building)
+- Requires sdl2. By default, a feature is enabled to automatically compile it for you, but you are free to disable it and follow [these instructions](https://github.com/Rust-SDL2/rust-sdl2#requirements)
+
+## Usage
+
 ```rust
 /* called once (top level initialization) */
 
@@ -22,6 +26,7 @@ plays videos in egui from file path or from bytes
     add_audio_device_to_state_somewhere(audio_device);
 }
 ```
+
 ```rust
 /* called once (creating a player) */
 
@@ -31,12 +36,16 @@ let mut player = Player::new(ctx, my_media_path)?;
     player = player.with_audio(&mut my_state.audio_device)
 }
 ```
+
 ```rust
 /* called every frame (showing the player) */
 player.ui(ui, [player.width as f32, player.height as f32]);
 ```
-## contributions
+
+## Contributions
+
 are welcome :)
 
-### current caveats
- - need to compile in `release` or `opt-level=3` otherwise limited playback performance
+### Current caveats
+
+- Need to compile in `release` or `opt-level=3` otherwise limited playback performance

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 https://github.com/n00kii/egui-video/assets/57325298/c618ff0a-9ad2-4cf0-b14a-dda65dc54b23
 
-Plays videos in egui from file path or from bytes.
+Plays videos in egui from file path, bytes or socket (live stream).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs](https://docs.rs/egui-video/badge.svg)](https://docs.rs/egui-video/0.5.2/egui_video/)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/n00kii/egui-video/blob/main/README.md)
 
-![Demo](https://github.com/n00kii/egui-video/assets/57325298/c618ff0a-9ad2-4cf0-b14a-dda65dc54b23)
+https://github.com/n00kii/egui-video/assets/57325298/c618ff0a-9ad2-4cf0-b14a-dda65dc54b23
 
 Plays videos in egui from file path or from bytes.
 

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,0 +1,157 @@
+use eframe::NativeOptions;
+use egui::{CentralPanel, DragValue, Grid, Sense, Slider, TextEdit, Window};
+use egui_video::{AudioDevice, Player};
+fn main() {
+    let _ = eframe::run_native(
+        "app",
+        NativeOptions::default(),
+        Box::new(|| Box::new(App::default())),
+    );
+}
+struct App {
+    audio_device: AudioDevice,
+    player: Option<Player>,
+
+    media_path: String,
+    stream_size_scale: f32,
+    seek_frac: f32,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            audio_device: egui_video::init_audio_device_default()
+                .unwrap(),
+            media_path: String::new(),
+            stream_size_scale: 1.,
+            seek_frac: 0.,
+            player: None,
+        }
+    }
+}
+
+impl eframe::App for App {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        ctx.request_repaint();
+        CentralPanel::default().show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.add_enabled_ui(!self.media_path.is_empty(), |ui| {
+                    if ui.button("load").clicked() {
+                        match Player::new(ctx, &self.media_path.replace("\"", ""))
+                            .and_then(|p| p.with_audio(&mut self.audio_device))
+                        {
+                            Ok(player) => {
+                                self.player = Some(player);
+                            }
+                            Err(e) => println!("failed to make stream: {e}"),
+                        }
+                    }
+                });
+                ui.add_enabled_ui(!self.media_path.is_empty(), |ui| {
+                    if ui.button("clear").clicked() {
+                        self.player = None;
+                    }
+                });
+
+                let tedit_resp = ui.add_sized(
+                    [ui.available_width(), ui.available_height()],
+                    TextEdit::singleline(&mut self.media_path)
+                        .hint_text("click to set path")
+                        .interactive(false),
+                );
+
+                if ui
+                    .interact(
+                        tedit_resp.rect,
+                        tedit_resp.id.with("click_sense"),
+                        Sense::click(),
+                    )
+                    .clicked()
+                {
+                    if let Some(path_buf) = rfd::FileDialog::new()
+                        .add_filter("videos", &["mp4", "gif", "webm"])
+                        .pick_file()
+                    {
+                        self.media_path = path_buf.as_path().to_string_lossy().to_string();
+                    }
+                }
+            });
+            ui.separator();
+            if let Some(player) = self.player.as_mut() {
+                Window::new("info").show(ctx, |ui| {
+                    Grid::new("info_grid").show(ui, |ui| {
+                        ui.label("frame rate");
+                        ui.label(player.framerate.to_string());
+                        ui.end_row();
+
+                        ui.label("size");
+                        ui.label(format!("{}x{}", player.width, player.height));
+                        ui.end_row();
+
+                        ui.label("elapsed / duration");
+                        ui.label(player.duration_text());
+                        ui.end_row();
+
+                        ui.label("state");
+                        ui.label(format!("{:?}", player.player_state.get()));
+                        ui.end_row();
+
+                        ui.label("has audio?");
+                        ui.label(player.audio_streamer.is_some().to_string());
+                        ui.end_row();
+                    });
+                });
+                Window::new("controls").show(ctx, |ui| {
+                    ui.horizontal(|ui| {
+                        if ui.button("seek to:").clicked() {
+                            player.seek(self.seek_frac);
+                        }
+                        ui.add(
+                            DragValue::new(&mut self.seek_frac)
+                                .speed(0.05)
+                                .clamp_range(0.0..=1.0),
+                        );
+                        ui.checkbox(&mut player.looping, "loop");
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("size scale");
+                        ui.add(Slider::new(&mut self.stream_size_scale, 0.0..=2.));
+                    });
+                    ui.separator();
+                    ui.horizontal(|ui| {
+                        if ui.button("play").clicked() {
+                            player.start()
+                        }
+                        if ui.button("unpause").clicked() {
+                            player.resume();
+                        }
+                        if ui.button("pause").clicked() {
+                            player.pause();
+                        }
+                        if ui.button("stop").clicked() {
+                            player.stop();
+                        }
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("volume");
+                        let mut volume = player.audio_volume.get();
+                        if ui
+                            .add(Slider::new(&mut volume, 0.0..=player.max_audio_volume))
+                            .changed()
+                        {
+                            player.audio_volume.set(volume);
+                        };
+                    });
+                });
+
+                player.ui(
+                    ui,
+                    [
+                        player.width as f32 * self.stream_size_scale,
+                        player.height as f32 * self.stream_size_scale,
+                    ],
+                );
+            }
+        });
+    }
+}

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,6 +1,8 @@
 use eframe::NativeOptions;
-use egui::{CentralPanel, DragValue, Grid, Sense, Slider, TextEdit, Vec2, Window};
-use egui_video::{AudioDevice, Player};
+use egui::{CentralPanel, Vec2};
+use egui_video::Player;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 fn main() {
     let _ = eframe::run_native(
         "app",
@@ -23,8 +25,14 @@ impl eframe::App for App {
         ctx.request_repaint();
         CentralPanel::default().show(ctx, |ui| match self.player.as_mut() {
             None => {
-                self.player =
-                    Some(Player::new_ip(ctx, "udp://127.0.0.1:1234").expect("Media not found."));
+                println!("Starting stream");
+                self.player = Some(
+                    Player::new_udp(
+                        ctx,
+                        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1234),
+                    )
+                    .expect("Media not found."),
+                );
             }
             Some(p) => {
                 frame.set_window_size(Vec2 {

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,156 +1,37 @@
 use eframe::NativeOptions;
-use egui::{CentralPanel, DragValue, Grid, Sense, Slider, TextEdit, Window};
+use egui::{CentralPanel, DragValue, Grid, Sense, Slider, TextEdit, Vec2, Window};
 use egui_video::{AudioDevice, Player};
 fn main() {
     let _ = eframe::run_native(
         "app",
         NativeOptions::default(),
-        Box::new(|| Box::new(App::default())),
+        Box::new(|_| Box::new(App::default())),
     );
 }
 struct App {
-    audio_device: AudioDevice,
     player: Option<Player>,
-
-    media_path: String,
-    stream_size_scale: f32,
-    seek_frac: f32,
 }
 
 impl Default for App {
     fn default() -> Self {
-        Self {
-            audio_device: egui_video::init_audio_device_default()
-                .unwrap(),
-            media_path: String::new(),
-            stream_size_scale: 1.,
-            seek_frac: 0.,
-            player: None,
-        }
+        Self { player: None }
     }
 }
 
 impl eframe::App for App {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         ctx.request_repaint();
-        CentralPanel::default().show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.add_enabled_ui(!self.media_path.is_empty(), |ui| {
-                    if ui.button("load").clicked() {
-                        match Player::new(ctx, &self.media_path.replace("\"", ""))
-                            .and_then(|p| p.with_audio(&mut self.audio_device))
-                        {
-                            Ok(player) => {
-                                self.player = Some(player);
-                            }
-                            Err(e) => println!("failed to make stream: {e}"),
-                        }
-                    }
+        CentralPanel::default().show(ctx, |ui| match self.player.as_mut() {
+            None => {
+                self.player =
+                    Some(Player::new_ip(ctx, "udp://127.0.0.1:1234").expect("Media not found."));
+            }
+            Some(p) => {
+                frame.set_window_size(Vec2 {
+                    x: p.width as f32,
+                    y: p.height as f32,
                 });
-                ui.add_enabled_ui(!self.media_path.is_empty(), |ui| {
-                    if ui.button("clear").clicked() {
-                        self.player = None;
-                    }
-                });
-
-                let tedit_resp = ui.add_sized(
-                    [ui.available_width(), ui.available_height()],
-                    TextEdit::singleline(&mut self.media_path)
-                        .hint_text("click to set path")
-                        .interactive(false),
-                );
-
-                if ui
-                    .interact(
-                        tedit_resp.rect,
-                        tedit_resp.id.with("click_sense"),
-                        Sense::click(),
-                    )
-                    .clicked()
-                {
-                    if let Some(path_buf) = rfd::FileDialog::new()
-                        .add_filter("videos", &["mp4", "gif", "webm"])
-                        .pick_file()
-                    {
-                        self.media_path = path_buf.as_path().to_string_lossy().to_string();
-                    }
-                }
-            });
-            ui.separator();
-            if let Some(player) = self.player.as_mut() {
-                Window::new("info").show(ctx, |ui| {
-                    Grid::new("info_grid").show(ui, |ui| {
-                        ui.label("frame rate");
-                        ui.label(player.framerate.to_string());
-                        ui.end_row();
-
-                        ui.label("size");
-                        ui.label(format!("{}x{}", player.width, player.height));
-                        ui.end_row();
-
-                        ui.label("elapsed / duration");
-                        ui.label(player.duration_text());
-                        ui.end_row();
-
-                        ui.label("state");
-                        ui.label(format!("{:?}", player.player_state.get()));
-                        ui.end_row();
-
-                        ui.label("has audio?");
-                        ui.label(player.audio_streamer.is_some().to_string());
-                        ui.end_row();
-                    });
-                });
-                Window::new("controls").show(ctx, |ui| {
-                    ui.horizontal(|ui| {
-                        if ui.button("seek to:").clicked() {
-                            player.seek(self.seek_frac);
-                        }
-                        ui.add(
-                            DragValue::new(&mut self.seek_frac)
-                                .speed(0.05)
-                                .clamp_range(0.0..=1.0),
-                        );
-                        ui.checkbox(&mut player.looping, "loop");
-                    });
-                    ui.horizontal(|ui| {
-                        ui.label("size scale");
-                        ui.add(Slider::new(&mut self.stream_size_scale, 0.0..=2.));
-                    });
-                    ui.separator();
-                    ui.horizontal(|ui| {
-                        if ui.button("play").clicked() {
-                            player.start()
-                        }
-                        if ui.button("unpause").clicked() {
-                            player.resume();
-                        }
-                        if ui.button("pause").clicked() {
-                            player.pause();
-                        }
-                        if ui.button("stop").clicked() {
-                            player.stop();
-                        }
-                    });
-                    ui.horizontal(|ui| {
-                        ui.label("volume");
-                        let mut volume = player.audio_volume.get();
-                        if ui
-                            .add(Slider::new(&mut volume, 0.0..=player.max_audio_volume))
-                            .changed()
-                        {
-                            player.audio_volume.set(volume);
-                        };
-                    });
-                });
-
-                player.ui(
-                    ui,
-                    [
-                        player.width as f32 * self.stream_size_scale,
-                        player.height as f32 * self.stream_size_scale,
-                    ],
-                );
+                p.ui(ui, [p.width as f32, p.height as f32]);
             }
         });
     }


### PR DESCRIPTION
Fixed some spelling and added support for streaming video over socket.

Some solutions might be a little "hacky", e.g. framerate is set to 500 and used to check for new frames often and the actual framerate is used to "catch up" to the live portion of the stream by dropping frames.

The video is also set to start as part of new_udp() since it seemed more natural for streaming videos.

The feature can be tested using ffmpeg with the settings below.

```bash
ffmpeg -f lavfi -i mptestsrc -preset ultrafast -vcodec libx264 -tune zerolatency -b 900k -f mpegts udp://127.0.0.1:1234
```

Audio is untested.

Hopefully it can be of use.