### PR TITLE
Dependency updates: egui & ffmpeg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ from_bytes = ["dep:tempfile"]
 sdl2-bundled = ["sdl2/bundled"]
 
 [dependencies]
-egui = "0.23.0"
+egui = "0.27.0"
 atomic = "0.5.3"
 ffmpeg-the-third = "1.2.2"
 anyhow = "1.0.75"
@@ -33,4 +33,4 @@ nom = "7.1.3"
 
 [dev-dependencies]
 rfd = "0.11.0"
-eframe = "0.23.0"
+eframe = "0.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ from_bytes = ["dep:tempfile"]
 sdl2-bundled = ["sdl2/bundled"]
 
 [dependencies]
-egui = "0.27.0"
+egui = "0.28.0"
 atomic = "0.5.3"
 ffmpeg-the-third = "2.0.1"
 anyhow = "1.0.75"
@@ -33,4 +33,4 @@ nom = "7.1.3"
 
 [dev-dependencies]
 rfd = "0.11.0"
-eframe = "0.27.0"
+eframe = "0.28.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ sdl2-bundled = ["sdl2/bundled"]
 [dependencies]
 egui = "0.27.0"
 atomic = "0.5.3"
-ffmpeg-the-third = "1.2.2"
+ffmpeg-the-third = "2.0.1"
 anyhow = "1.0.75"
 timer = "0.2.0"
 chrono = "0.4.31"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://github.com/n00kii/egui-video/assets/57325298/c618ff0a-9ad2-4cf0-b14a-dda
 plays videos in egui from file path or from bytes
 
 ## dependancies:
- - requires ffmpeg 6. follow the build instructions [here](https://github.com/zmwangx/rust-ffmpeg/wiki/Notes-on-building)
+ - requires ffmpeg 6 or 7. follow the build instructions [here](https://github.com/zmwangx/rust-ffmpeg/wiki/Notes-on-building)
  - requires sdl2. by default, a feature is enabled to automatically compile it for you, but you are free to disable it and follow [these instructions](https://github.com/Rust-SDL2/rust-sdl2#requirements)
 ## usage:
 ```rust

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -5,7 +5,7 @@ fn main() {
     let _ = eframe::run_native(
         "app",
         NativeOptions::default(),
-        Box::new(|_| Box::new(App::default())),
+        Box::new(|_| Ok(Box::new(App::default()))),
     );
 }
 struct App {
@@ -113,7 +113,7 @@ impl eframe::App for App {
                         ui.add(
                             DragValue::new(&mut self.seek_frac)
                                 .speed(0.05)
-                                .clamp_range(0.0..=1.0),
+                                .range(0.0..=1.0),
                         );
                         ui.checkbox(&mut player.options.looping, "loop");
                     });
@@ -140,7 +140,10 @@ impl eframe::App for App {
                         ui.label("volume");
                         let mut volume = player.options.audio_volume.get();
                         if ui
-                            .add(Slider::new(&mut volume, 0.0..=player.options.max_audio_volume))
+                            .add(Slider::new(
+                                &mut volume,
+                                0.0..=player.options.max_audio_volume,
+                            ))
                             .changed()
                         {
                             player.options.audio_volume.set(volume);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,7 @@ impl Player {
             };
             let spinner_size = 20. * seek_indicator_anim;
             ui.painter()
-                .add(seek_indicator_shadow.tessellate(frame_response.rect, Rounding::ZERO));
+                .add(seek_indicator_shadow.as_shape(frame_response.rect, Rounding::ZERO));
             ui.put(
                 Rect::from_center_size(frame_response.rect.center(), Vec2::splat(spinner_size)),
                 Spinner::new().size(spinner_size),
@@ -693,12 +693,12 @@ impl Player {
 
         let mut shadow_rect = frame_response.rect;
         shadow_rect.set_top(shadow_rect.bottom() - seekbar_offset - 10.);
-        let shadow_mesh = shadow.tessellate(shadow_rect, Rounding::ZERO);
 
         let fullseekbar_color = Color32::GRAY.linear_multiply(seekbar_anim_frac);
         let seekbar_color = Color32::WHITE.linear_multiply(seekbar_anim_frac);
 
-        ui.painter().add(shadow_mesh);
+        ui.painter()
+            .add(shadow.as_shape(shadow_rect, Rounding::ZERO));
 
         ui.painter().rect_filled(
             fullseekbar_rect,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1269,7 +1269,8 @@ pub trait Streamer: Send {
     }
     /// Recieve the next packet of the stream.
     fn recieve_next_packet(&mut self) -> Result<()> {
-        if let Some(Ok((stream, packet))) = self.input_context().packets().next() {
+        if let Some(packet) = self.input_context().packets().next() {
+            let (stream, packet) = packet?;
             let time_base = stream.time_base();
             if stream.index() == self.stream_index() {
                 self.decoder().send_packet(&packet)?;
@@ -1498,7 +1499,8 @@ impl Streamer for SubtitleStreamer {
         &self.player_state
     }
     fn recieve_next_packet(&mut self) -> Result<()> {
-        if let Some(Ok((stream, packet))) = self.input_context().packets().next() {
+        if let Some(packet) = self.input_context().packets().next() {
+            let (stream, packet) = packet?;
             let time_base = stream.time_base();
             if stream.index() == self.stream_index() {
                 if let Some(dts) = packet.dts() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,10 +604,12 @@ impl Player {
         );
 
         if currently_seeking {
-            let mut seek_indicator_shadow = Shadow::big_dark();
-            seek_indicator_shadow.color = seek_indicator_shadow
-                .color
-                .linear_multiply(seek_indicator_anim);
+            let seek_indicator_shadow = Shadow {
+                offset: vec2(10.0, 20.0),
+                blur: 15.0,
+                spread: 0.0,
+                color: Color32::from_black_alpha(96).linear_multiply(seek_indicator_anim),
+            };
             let spinner_size = 20. * seek_indicator_anim;
             ui.painter()
                 .add(seek_indicator_shadow.tessellate(frame_response.rect, Rounding::ZERO));
@@ -682,8 +684,12 @@ impl Player {
         let mut duration_text_font_id = FontId::default();
         duration_text_font_id.size = 14.;
 
-        let mut shadow = Shadow::big_light();
-        shadow.color = shadow.color.linear_multiply(seekbar_anim_frac);
+        let shadow = Shadow {
+            offset: vec2(10.0, 20.0),
+            blur: 15.0,
+            spread: 0.0,
+            color: Color32::from_black_alpha(25).linear_multiply(seekbar_anim_frac),
+        };
 
         let mut shadow_rect = frame_response.rect;
         shadow_rect.set_top(shadow_rect.bottom() - seekbar_offset - 10.);


### PR DESCRIPTION
This PR bumps egui to 0.28.0 and ffmpeg-the-thrid to 2.0.1. This makes the project compatible with ffmpeg7.

The `input_context().packets()` iterator now returns result items, for now I decided to just propagate them with `?` as is done elsewhere in the affected functions. Let me know if you think a different approach would be more suitable here.

After the changes I ran the main example in this repo, everything seems to work fine. Tested on Arch with ffmpeg 7.0.1 installed.

From my understanding, the crate should still be compatible with ffmpeg6, but note that I haven't actually tested that.