### PR TITLE
set hint to prevent SDL from configuring a signal handler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ impl AudioDevice {
 
     /// Create a new [`AudioDevice`]. Creates an [`sdl2::AudioSubsystem`]. An [`AudioDevice`] is required for using audio.
     pub fn new() -> Result<AudioDevice, String> {
+        // without setting this hint, SDL captures SIGINT (Ctrl+C) and because we are not handling SDL events
+        // this prevents the application from closing
+        sdl2::hint::set("SDL_NO_SIGNAL_HANDLERS", "1");
         Self::from_subsystem(&sdl2::init()?.audio()?)
     }
 }


### PR DESCRIPTION
After `AudioDevice` is created, pressing `Ctrl+C` no longer quits the application. During `sdl2::init()` SDL sets a signal handler so that the signal resulting from `Ctrl+C` gets stored as an `sdl2::Event::Quit` event, but since nothing polls the SDL event loop the signal is ignored.