### PR TITLE
Optionally allow user to depend on eframe::egui instead of egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ egui = "0.30.0"
 eframe = { version = "0.30.0", optional = true }
 atomic = "0.6.0"
 bytemuck = { version = "1.21.0", features = ["derive"]}
-ffmpeg-the-third = "2.0.1"
+ffmpeg-next = "7.1.0"
 anyhow = "1.0.95"
 timer = "0.2.0"
 chrono = "0.4.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["n00kii"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["sdl2/bundled"]
+default = ["sdl2/bundled", "eframe", "from_bytes"]
 from_bytes = ["dep:tempfile"]
 # will compile sdl2 for you if you do not have it
 # this may require other dependancies (see https://github.com/Rust-SDL2/rust-sdl2#bundled-feature)
@@ -19,21 +19,20 @@ sdl2-bundled = ["sdl2/bundled"]
 eframe = ["dep:eframe"]
 
 [dependencies]
-egui = "0.29"
+egui = "0.30.0"
 eframe = { version = "0.30.0", optional = true }
 atomic = "0.6.0"
-bytemuck = { version = "1.19", features = ["derive"]}
+bytemuck = { version = "1.21.0", features = ["derive"]}
 ffmpeg-the-third = "2.0.1"
-anyhow = "1.0.86"
+anyhow = "1.0.95"
 timer = "0.2.0"
-chrono = "0.4.38"
-tempfile = { version = "3.12.0", optional = true }
+chrono = "0.4.39"
+tempfile = { version = "3.15.0", optional = true }
 sdl2 = { version = "0.37.0" }
-ringbuf = "0.4.4"
+ringbuf = "0.4.7"
 parking_lot = "0.12.3"
-itertools = "0.13.0"
 nom = "7.1.3"
 
 [dev-dependencies]
 rfd = "0.15.0"
-eframe = "0.29"
+eframe = "0.30.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["n00kii"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["sdl2/bundled", "eframe", "from_bytes"]
+default = ["sdl2/bundled"]
 from_bytes = ["dep:tempfile"]
 # will compile sdl2 for you if you do not have it
 # this may require other dependancies (see https://github.com/Rust-SDL2/rust-sdl2#bundled-feature)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ from_bytes = ["dep:tempfile"]
 # will compile sdl2 for you if you do not have it
 # this may require other dependancies (see https://github.com/Rust-SDL2/rust-sdl2#bundled-feature)
 sdl2-bundled = ["sdl2/bundled"]
+eframe = ["dep:eframe"]
 
 [dependencies]
 egui = "0.29"
+eframe = { version = "0.30.0", optional = true }
 atomic = "0.6.0"
 bytemuck = { version = "1.19", features = ["derive"]}
 ffmpeg-the-third = "2.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use atomic::Atomic;
 use bytemuck::NoUninit;
 use chrono::{DateTime, Duration, Utc};
+
 #[cfg(feature = "eframe")]
 use eframe::egui::{
     emath::RectTransform, epaint::Shadow, load::SizedTexture, vec2, Align2, Color32, ColorImage,
@@ -22,25 +23,29 @@ use egui::{
     Context, FontId, Image, Pos2, Rect, Response, Rounding, Sense, Spinner, TextureHandle,
     TextureOptions, Ui, Vec2,
 };
-use ffmpeg::error::EAGAIN;
-use ffmpeg::ffi::{AVERROR, AV_TIME_BASE};
-use ffmpeg::format::context::input::Input;
-use ffmpeg::format::{input, Pixel};
-use ffmpeg::frame::Audio;
-use ffmpeg::media::Type;
-use ffmpeg::software::scaling::flag::Flags;
-use ffmpeg::util::frame::video::Video;
-use ffmpeg::{rescale, Packet, Rational, Rescale};
-use ffmpeg::{software, ChannelLayout};
+use ffmpeg::{
+    error::EAGAIN,
+    ffi::{AVERROR, AV_TIME_BASE},
+    format::{context::input::Input, input, Pixel},
+    frame::Audio,
+    media::Type,
+    software::scaling::flag::Flags,
+    util::frame::video::Video,
+    {rescale, Packet, Rational, Rescale}, {software, ChannelLayout},
+};
 use parking_lot::Mutex;
-use ringbuf::traits::{Consumer, Observer, Producer, Split};
-use ringbuf::wrap::caching::Caching;
-use ringbuf::HeapRb;
+use ringbuf::{
+    traits::{Consumer, Observer, Producer, Split},
+    wrap::caching::Caching,
+    HeapRb,
+};
 use sdl2::audio::{self, AudioCallback, AudioFormat, AudioSpecDesired};
-use std::collections::VecDeque;
-use std::ops::Deref;
-use std::sync::{Arc, Weak};
-use std::time::UNIX_EPOCH;
+use std::{
+    collections::VecDeque,
+    ops::Deref,
+    sync::{Arc, Weak},
+    time::UNIX_EPOCH,
+};
 use subtitle::Subtitle;
 use timer::{Guard, Timer};
 

--- a/src/subtitle/ass.rs
+++ b/src/subtitle/ass.rs
@@ -1,4 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
+#[cfg(feature = "eframe")]
+use eframe::egui::{Align2, Color32, Pos2};
+#[cfg(not(feature = "eframe"))]
 use egui::{Align2, Color32, Pos2};
 use nom::branch::alt;
 use nom::bytes::complete::{is_not, tag, take_till, take_until, take_while_m_n};
@@ -22,7 +25,10 @@ fn tuple_int_2(v: Vec<f64>) -> Result<(i64, i64)> {
 
 fn tuple_float_2(v: Vec<f64>) -> Result<(f64, f64)> {
     const FAIL_TEXT: &str = "invalid number of items";
-    Ok((*v.first().context(FAIL_TEXT)?, *v.get(1).context(FAIL_TEXT)?))
+    Ok((
+        *v.first().context(FAIL_TEXT)?,
+        *v.get(1).context(FAIL_TEXT)?,
+    ))
 }
 
 fn fad(i: &str) -> IResult<&str, SubtitleField> {
@@ -143,10 +149,7 @@ fn opt_comma(i: &str) -> IResult<&str, Option<char>> {
 }
 
 fn string_field(i: &str) -> IResult<&str, Option<String>> {
-    preceded(
-        opt_comma,
-        map(opt(not_comma), |s| s.map(String::from)),
-    )(i)
+    preceded(opt_comma, map(opt(not_comma), |s| s.map(String::from)))(i)
 }
 
 fn num_field(i: &str) -> IResult<&str, i32> {

--- a/src/subtitle/mod.rs
+++ b/src/subtitle/mod.rs
@@ -1,4 +1,7 @@
 use anyhow::Result;
+#[cfg(feature = "eframe")]
+use eframe::egui::{Align2, Color32, Margin, Pos2};
+#[cfg(not(feature = "eframe"))]
 use egui::{Align2, Color32, Margin, Pos2};
 
 use self::ass::parse_ass_subtitle;


### PR DESCRIPTION
Primary purpose is to support integration with projects which rely on eframe, not egui.
Import changes to help support this and "cargo fmt" formatting changes.
I configured it with the current latest version of eframe and didn't update any other dependencies. I also didn't use the same feature flag to disable egui, though I think that would make sense.